### PR TITLE
Feat: 에러 응답 객체 형식을 지정해서 반환할 수 있도록 관련 파일들 추가

### DIFF
--- a/src/main/java/com/zerobase/CafeBom/exception/CustomException.java
+++ b/src/main/java/com/zerobase/CafeBom/exception/CustomException.java
@@ -1,7 +1,6 @@
 package com.zerobase.CafeBom.exception;
 
 import com.zerobase.CafeBom.type.ErrorCode;
-
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 

--- a/src/main/java/com/zerobase/CafeBom/exception/CustomException.java
+++ b/src/main/java/com/zerobase/CafeBom/exception/CustomException.java
@@ -1,0 +1,18 @@
+package com.zerobase.CafeBom.exception;
+
+import com.zerobase.CafeBom.type.ErrorCode;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+    private final String errorMessage;
+
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getDescription()); // 이 부분 ExceptionHandler 로 처리하라고 피드백 받음.
+        this.errorCode = errorCode;
+        this.errorMessage = errorCode.getDescription();
+    }
+}

--- a/src/main/java/com/zerobase/CafeBom/exception/CustomException.java
+++ b/src/main/java/com/zerobase/CafeBom/exception/CustomException.java
@@ -3,16 +3,19 @@ package com.zerobase.CafeBom.exception;
 import com.zerobase.CafeBom.type.ErrorCode;
 
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
 
 @Getter
 public class CustomException extends RuntimeException {
 
     private final ErrorCode errorCode;
     private final String errorMessage;
+    private final HttpStatus errorStatus;
 
     public CustomException(ErrorCode errorCode) {
-        super(errorCode.getDescription()); // 이 부분 ExceptionHandler 로 처리하라고 피드백 받음.
+        super(errorCode.getDescription());
         this.errorCode = errorCode;
         this.errorMessage = errorCode.getDescription();
+        this.errorStatus = errorCode.getHttpStatus();
     }
 }

--- a/src/main/java/com/zerobase/CafeBom/exception/CustomException.java
+++ b/src/main/java/com/zerobase/CafeBom/exception/CustomException.java
@@ -12,9 +12,9 @@ public class CustomException extends RuntimeException {
     private final HttpStatus errorStatus;
 
     public CustomException(ErrorCode errorCode) {
-        super(errorCode.getDescription());
+        super(errorCode.getMessage());
         this.errorCode = errorCode;
-        this.errorMessage = errorCode.getDescription();
+        this.errorMessage = errorCode.getMessage();
         this.errorStatus = errorCode.getHttpStatus();
     }
 }

--- a/src/main/java/com/zerobase/CafeBom/exception/ExceptionController.java
+++ b/src/main/java/com/zerobase/CafeBom/exception/ExceptionController.java
@@ -1,0 +1,34 @@
+package com.zerobase.CafeBom.exception;
+
+import com.zerobase.CafeBom.type.ErrorCode;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+@Slf4j
+public class ExceptionController {
+
+    @ExceptionHandler({CustomException.class})
+    public ResponseEntity<ExceptionResponse> customRequestException(final CustomException c) {
+        log.error("Api Exception => {}", c.getErrorCode());
+        return ResponseEntity
+            .status(c.getErrorStatus())
+            .body(ExceptionResponse.builder()
+                .errorCode(c.getErrorCode())
+                .errorMessage(c.getErrorMessage())
+                .build()
+            );
+    }
+
+    @Getter
+    @Builder
+    public static class ExceptionResponse {
+
+        private ErrorCode errorCode;
+        private String errorMessage;
+    }
+}

--- a/src/main/java/com/zerobase/CafeBom/type/ErrorCode.java
+++ b/src/main/java/com/zerobase/CafeBom/type/ErrorCode.java
@@ -9,6 +9,6 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
     EXAMPLE("예시입니다. 처음 추가하는 분이 삭제해주세요.", HttpStatus.BAD_REQUEST);
 
-    private final String description;
+    private final String message;
     private final HttpStatus httpStatus;
 }

--- a/src/main/java/com/zerobase/CafeBom/type/ErrorCode.java
+++ b/src/main/java/com/zerobase/CafeBom/type/ErrorCode.java
@@ -1,0 +1,14 @@
+package com.zerobase.CafeBom.type;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+    EXAMPLE("예시입니다. 처음 추가하는 분이 삭제해주세요.", HttpStatus.BAD_REQUEST);
+
+    private final String description;
+    private final HttpStatus httpStatus;
+}


### PR DESCRIPTION
### ☀️ 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**🌱 AS-IS**
- api 요청 처리 시 발생하는 예외, client에 보내주는 에러 응답 형식을 컨벤션으로 만들고 코드 상 구현된 부분은 없었음.

**🌷 TO-BE**
- ErrorCode enum 으로 각 상황에 대한 ErrorCode, ErrorMessage, HTTPStatus 설정
- CustomException을 통해 예외 발생
- ExceptionController를 통해 CustomException 발생 시 client에게 지정된 형식으로 응답 전달

```
   {
      errorCode: "USER_NOT_FOUND"
      errorMessage: "사용자를 찾을 수 없습니다."
   }
```

### 🗣️ Comment
<!-- 팀원들에게 질문이 있다던가, 이 PR에 대해 추가적인 설명 -->
- 에러 응답 형식 부분은 원래 message만 전달하는 방향으로 얘기가 되었는데
  다른 코드들을 참고하다보니 에러코드도 `대문자 스네이크 케이스`로 전달하는 경우가 많아서
  같이 전달해주면 어떨까 해서 추가했습니다. 괜찮다고 해주시면 이대로 머지하고,
  원래대로 하자고 해주시면 메세지만 보내는 걸로 하겠습니다!
- 이 PR은 팀원분들 전부 승인해주시면 머지하겠습니다~

### ⚡️ 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드 -> 해당없음
- [ ] 전체 테스트 성공 -> 해당없음
- [ ] API 테스트 -> 해당없음
- 제 개인프로젝트를 통해 어떤 형식으로 나오는지 테스트 한 스냅샷 첨부합니다.
403 forbidden은 ErrorCode에서 설정한 HTTPStatus 코드입니다.
사용자에게 전달되는 상태코드이므로 컨벤션에 맞게 설정해주시면 됩니다~!
<img width="592" alt="익셉션 1" src="https://github.com/YesunPark/cafe-bom/assets/108933466/1b623a3a-cb40-41e9-b7a4-50176f727457">
<img width="1118" alt="익셉션 2" src="https://github.com/YesunPark/cafe-bom/assets/108933466/f6eede66-f4ef-4c2f-bd51-a01c59135d8e">

