### PR TITLE
Fix: TokenProvider, AuthService에서 인증정보 추출하는 메서드 수정, 토큰 추출하는 메서드 추가

### DIFF
--- a/src/main/java/com/zerobase/cafebom/member/security/TokenProvider.java
+++ b/src/main/java/com/zerobase/cafebom/member/security/TokenProvider.java
@@ -1,6 +1,5 @@
 package com.zerobase.cafebom.member.security;
 
-
 import com.zerobase.cafebom.member.service.AuthService;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -57,9 +56,9 @@ public class TokenProvider {
         return parseClaims(token).getSubject();
     }
 
-    // 토큰에서 사용자 id 추출-yesun-23.08.21
+    // 토큰에서 사용자 id 추출-yesun-23.08.25
     public Long getId(String token) {
-        return Long.parseLong(parseClaims(token).getId());
+        return Long.parseLong(parseClaims(removeBearerFromToken(token)).getId());
     }
 
     // 토큰 유효성검사-yesun-23.08.21
@@ -79,5 +78,11 @@ public class TokenProvider {
         } catch (ExpiredJwtException e) {
             return e.getClaims();
         }
+    }
+
+    // 토큰 인증 타입 제거-yesun-23.08.25
+    private String removeBearerFromToken(String token) {
+        String TOKEN_PREFIX = "Bearer ";
+        return token.substring(TOKEN_PREFIX.length());
     }
 }

--- a/src/main/java/com/zerobase/cafebom/member/security/TokenProvider.java
+++ b/src/main/java/com/zerobase/cafebom/member/security/TokenProvider.java
@@ -45,15 +45,15 @@ public class TokenProvider {
             .compact();
     }
 
-    // jwt 에서 인증정보 추출-yesun-23.08.21
+    // jwt 에서 인증정보 추출-yesun-23.08.25
     public Authentication getAuthentication(String token) {
-        UserDetails userDetails = authService.loadUserByUsername(getPhone(token));
+        UserDetails userDetails = authService.loadUserByUsername(getEmail(token));
         return new UsernamePasswordAuthenticationToken(userDetails, "",
             userDetails.getAuthorities());
     }
 
-    // 토큰에서 사용자 휴대전화번호 추출-yesun-23.08.21
-    public String getPhone(String token) {
+    // 토큰에서 사용자 이메일 추출-yesun-23.08.25
+    public String getEmail(String token) {
         return parseClaims(token).getSubject();
     }
 

--- a/src/main/java/com/zerobase/cafebom/member/service/AuthService.java
+++ b/src/main/java/com/zerobase/cafebom/member/service/AuthService.java
@@ -60,8 +60,8 @@ public class AuthService implements UserDetailsService {
     }
 
     @Override
-    public UserDetails loadUserByUsername(String nickname) throws UsernameNotFoundException {
-        Member member = memberRepository.findByNickname(nickname).orElseThrow(
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        Member member = memberRepository.findByEmail(email).orElseThrow(
             () -> new CustomException(MEMBER_NOT_EXISTS)
         );
 


### PR DESCRIPTION
### ☀️ 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**🌱 AS-IS**
1. 토큰 생성 시 subject에 이메일 정보를 넣는데 실수로 전화번호로 추출한다고 메서드 명을 잘못 지음
2. 유저 검증시 이메일로 정보를 찾아와야 하는데 닉네임으로 찾아옴
3. 토큰의 Bearer를 제거하는 메서드가 따로 없어서 Tokenprovider의 getId메서드를 호출할 때마다 Bearer를 제거해서 넣어줘야 했었음.

**🌷 TO-BE**
1. 메서드명과 변수명을 의도에 맞게 수정했습니다.
2. 닉네임이 아닌 이메일로 찾아오도록 했습니다.
3. 받은 Bearer token을 그대로 getId 메서드에 넣으면 바로 사용가능합니다.


### 🗣️ Comment
<!-- 팀원들에게 질문이 있다던가, 이 PR에 대해 추가적인 설명 -->
- 추가 사항 없습니다.

### ⚡️ 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 전체 테스트 성공