### PR TITLE
Fix: 장바구니 엔티티에 주문 상태 컬럼 추가, isOrdered 컬럼 삭제

### DIFF
--- a/src/main/java/com/zerobase/cafebom/cart/domain/entity/Cart.java
+++ b/src/main/java/com/zerobase/cafebom/cart/domain/entity/Cart.java
@@ -1,12 +1,21 @@
 package com.zerobase.cafebom.cart.domain.entity;
 
+import com.zerobase.cafebom.cart.domain.entity.type.CartOrderStatus;
 import com.zerobase.cafebom.common.BaseTimeEntity;
-import com.zerobase.cafebom.product.domain.entity.Product;
 import com.zerobase.cafebom.member.domain.entity.Member;
-import lombok.*;
-
-import javax.persistence.*;
+import com.zerobase.cafebom.product.domain.entity.Product;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import javax.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Builder
 @Getter
@@ -31,5 +40,5 @@ public class Cart extends BaseTimeEntity {
     private Integer count;
 
     @NotNull
-    private Boolean isOrdered;
+    private CartOrderStatus status;
 }

--- a/src/main/java/com/zerobase/cafebom/cart/domain/entity/type/CartOrderStatus.java
+++ b/src/main/java/com/zerobase/cafebom/cart/domain/entity/type/CartOrderStatus.java
@@ -1,0 +1,6 @@
+package com.zerobase.cafebom.cart.domain.entity.type;
+
+public enum CartOrderStatus {
+    BEFORE_ORDER,
+    WAITING_ACCEPTANCE
+}

--- a/src/test/java/com/zerobase/cafebom/orders/service/OrdersServiceTest.java
+++ b/src/test/java/com/zerobase/cafebom/orders/service/OrdersServiceTest.java
@@ -82,7 +82,6 @@ class OrdersServiceTest {
         .member(member)
         .product(Product.builder().build())
         .count(2)
-        .isOrdered(false)
         .build();
 
     // yesun-23.08.31


### PR DESCRIPTION
### ☀️ 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**🌱 AS-IS**
- 사용자가 장바구니의 상품들을 주문했을 때 장바구니의 상품들이 삭제되지도 않고, 상태가 변경되지도 않아서 장바구니에 상품이 그대로 남아있을 수 밖에 없는 구조.
- isOrdered 컬럼은 삭제하기로 했는데 남아있었음.

**🌷 TO-BE**
- 장바구니 테이블에 status 컬럼을 추가해서 주문이 들어가기 전 장바구니인지, 주문이 들어갔는데 승인 대기 중인 장바구니인지 상태를 표시
   - 주문이 들어가기 전 : BEFORE_ORDER
   - 주문이 들어갔는데 승인 대기 중 : WAITING_ACCEPTANCE
- isOrdered 컬럼 삭제

### 🗣️ Comment
<!-- 팀원들에게 질문이 있다던가, 이 PR에 대해 추가적인 설명 -->
- 상태 ENUM 네이밍은 임의대로 했는데 혹시 네이밍만 보고 어떤 상태인지 직관적으로 알 수 없을 것 같으면 수정하고 머지할테니 더 좋은 의견 있으시면 말씀해주세요!

### ⚡️ 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- 테스트 코드 -> 해당 없음
- [x] 전체 테스트 성공
- API 테스트 -> 해당 없음