### PR TITLE
Docs: 스웨거 이너클래스 스키마 표시오류 '@ApiModel' 어노테이션으로 해결

### DIFF
--- a/src/main/java/com/zerobase/cafebom/admin/dto/AdminOptionCategoryForm.java
+++ b/src/main/java/com/zerobase/cafebom/admin/dto/AdminOptionCategoryForm.java
@@ -1,5 +1,6 @@
 package com.zerobase.cafebom.admin.dto;
 
+import io.swagger.annotations.ApiModel;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,6 +10,7 @@ import javax.validation.constraints.Size;
 
 public class AdminOptionCategoryForm {
 
+    @ApiModel(value = "AdminOptionCategoryFormRequest")
     @Getter
     public static class Request {
         @Schema(description = "옵션 카테고리명", example = "샷추가")
@@ -17,6 +19,7 @@ public class AdminOptionCategoryForm {
         private String name;
     }
 
+    @ApiModel(value ="AdminOptionCategoryFormResponse" )
     @Getter
     @Builder
     public static class Response {

--- a/src/main/java/com/zerobase/cafebom/admin/dto/AdminProductCategoryForm.java
+++ b/src/main/java/com/zerobase/cafebom/admin/dto/AdminProductCategoryForm.java
@@ -1,5 +1,6 @@
 package com.zerobase.cafebom.admin.dto;
 
+import io.swagger.annotations.ApiModel;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
@@ -9,6 +10,17 @@ import javax.validation.constraints.Size;
 
 public class AdminProductCategoryForm {
 
+    @ApiModel(value = "AdminProductCategoryFormRequest")
+    @Getter
+    public static class Request {
+
+        @Schema(description = "상품 카테고리명", example = "커피")
+        @Pattern(regexp = "^[가-힣a-zA-Z]+$", message = "상품 카테고리명은 한글, 영어 대소문자만 입력해야 합니다.")
+        @Size(min = 1, max = 20, message = "상품 카테고리명은 1~20 자리로 입력해야 합니다.")
+        private String name;
+    }
+
+    @ApiModel(value = "AdminProductCategoryFormResponse")
     @Getter
     @Builder
     public static class Response {
@@ -17,20 +29,12 @@ public class AdminProductCategoryForm {
 
         private String name;
 
-        public static AdminProductCategoryForm.Response from(AdminProductCategoryDto.Response productCategoryDto) {
+        public static AdminProductCategoryForm.Response from(
+            AdminProductCategoryDto.Response productCategoryDto) {
             return Response.builder()
-                    .productCategoryId(productCategoryDto.getProductCategoryId())
-                    .name(productCategoryDto.getName())
-                    .build();
+                .productCategoryId(productCategoryDto.getProductCategoryId())
+                .name(productCategoryDto.getName())
+                .build();
         }
-    }
-
-    @Getter
-    public static class Request {
-
-        @Schema(description = "상품 카테고리명", example = "커피")
-        @Pattern(regexp = "^[가-힣a-zA-Z]+$", message = "상품 카테고리명은 한글, 영어 대소문자만 입력해야 합니다.")
-        @Size(min = 1, max = 20, message = "상품 카테고리명은 1~20 자리로 입력해야 합니다.")
-        private String name;
     }
 }

--- a/src/main/java/com/zerobase/cafebom/auth/dto/SigninForm.java
+++ b/src/main/java/com/zerobase/cafebom/auth/dto/SigninForm.java
@@ -1,5 +1,6 @@
 package com.zerobase.cafebom.auth.dto;
 
+import io.swagger.annotations.ApiModel;
 import io.swagger.v3.oas.annotations.media.Schema;
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
@@ -9,6 +10,7 @@ import lombok.Getter;
 
 public class SigninForm {
 
+    @ApiModel(value = "SigninFormRequest")
     @Getter
     public static class Request {
 
@@ -21,6 +23,7 @@ public class SigninForm {
         private String password;
     }
 
+    @ApiModel(value = "SigninFormResponse")
     @Getter
     @Builder
     public static class Response {

--- a/src/main/java/com/zerobase/cafebom/option/dto/OptionForm.java
+++ b/src/main/java/com/zerobase/cafebom/option/dto/OptionForm.java
@@ -1,6 +1,7 @@
 package com.zerobase.cafebom.option.dto;
 
 import com.zerobase.cafebom.option.domain.Option;
+import io.swagger.annotations.ApiModel;
 import io.swagger.v3.oas.annotations.media.Schema;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
@@ -9,6 +10,7 @@ import lombok.Getter;
 
 public class OptionForm {
 
+    @ApiModel(value = "OptionFormRequest")
     @Getter
     public static class Request {
 
@@ -27,6 +29,7 @@ public class OptionForm {
         private Integer price;
     }
 
+    @ApiModel(value = "OptionFormResponse")
     @Getter
     @Builder
     public static class Response {

--- a/src/main/java/com/zerobase/cafebom/orders/dto/OrdersAddForm.java
+++ b/src/main/java/com/zerobase/cafebom/orders/dto/OrdersAddForm.java
@@ -1,6 +1,7 @@
 package com.zerobase.cafebom.orders.dto;
 
 import com.zerobase.cafebom.type.Payment;
+import io.swagger.annotations.ApiModel;
 import io.swagger.v3.oas.annotations.media.Schema;
 import javax.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
@@ -10,6 +11,7 @@ import lombok.NoArgsConstructor;
 
 public class OrdersAddForm {
 
+    @ApiModel(value = "OrdersAddFormRequest")
     @Getter
     @Builder
     @AllArgsConstructor

--- a/src/main/java/com/zerobase/cafebom/review/controller/form/ReviewAddForm.java
+++ b/src/main/java/com/zerobase/cafebom/review/controller/form/ReviewAddForm.java
@@ -1,5 +1,6 @@
 package com.zerobase.cafebom.review.controller.form;
 
+import io.swagger.annotations.ApiModel;
 import io.swagger.v3.oas.annotations.media.Schema;
 import javax.validation.constraints.Min;
 import lombok.Builder;
@@ -8,6 +9,7 @@ import org.hibernate.validator.constraints.Range;
 
 public class ReviewAddForm {
 
+    @ApiModel(value = "ReviewAddFormRequest")
     @Builder
     @Getter
     public static class Request {


### PR DESCRIPTION
### ☀️ 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**🌱 AS-IS**
- 스웨거가 클래스의 이름만 인식하기 때문에 이너클래스로 사용했던 Request, Response 클래스들이
전부 하나의 클래스로 인식돼서 스키마가 잘 나오지 않았음.

**🌷 TO-BE**
- ApiModel 어노테이션으로 클래스에 각각의 이름을 지정해줌으로써 해결
- AdminProductCategoryForm 은 Request, Response 위치가 바뀌어져있어서 제가 임의로 위치 수정했습니다. 

### 🗣️ Comment
<!-- 팀원들에게 질문이 있다던가, 이 PR에 대해 추가적인 설명 -->
- 앞으로 추가하실 Form.Request 또는 Form.Response가 있다면 ApiModel 어노테이션을 추가해주시면 됩니다.
부모클래스명 + Request/Response를 value로 해서 달아주시면 됩니다!
- 최선의 방법은 아닐 수 있지만 프론트가 없는 프로젝트이다보니 스웨거에서 제대로 나타내는게 중요하다고 생각해 빠르게 수정할 수 있는 방법을 택했습니다. 추후 더 좋은 방법을 제안하고 싶으신 분은 수정 후 PR 올려주세요!

### ⚡️ 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- 테스트 코드 -> 해당없음
- [x] 전체 테스트 성공
- API 테스트 -> 해당없음