### PR TITLE
Refactor: 주문 관련 기능 관리자/사용자 권한 부여, RequestHeader에 사용자 토큰 추가

### DIFF
--- a/src/main/java/com/zerobase/cafebom/admin/controller/AdminOrdersController.java
+++ b/src/main/java/com/zerobase/cafebom/admin/controller/AdminOrdersController.java
@@ -11,8 +11,10 @@ import com.zerobase.cafebom.orders.dto.OrdersStatusModifyForm;
 import com.zerobase.cafebom.orders.service.OrdersService;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -25,40 +27,41 @@ import org.springframework.web.bind.annotation.RestController;
 @Controller
 @RequiredArgsConstructor
 @RequestMapping("/admin/orders")
+@PreAuthorize("hasRole('ROLE_ADMIN')")
 public class AdminOrdersController {
 
     private final OrdersService ordersService;
 
-    // minsu-23.09.12
+    // minsu-23.09.19
     @ApiOperation(value = "주문 상태 변경", notes = "관리자가 주문 상태를 변경합니다.")
     @PatchMapping("/status/{ordersId}")
     public ResponseEntity<Void> ordersStatusModify(
         @PathVariable Long ordersId,
-        @RequestBody OrdersStatusModifyForm ordersStatusModifyForm) {
+        @RequestBody @Valid OrdersStatusModifyForm ordersStatusModifyForm) {
 
         ordersService.modifyOrdersStatus(ordersId,
             OrdersStatusModifyDto.from(ordersStatusModifyForm));
         return ResponseEntity.status(NO_CONTENT).build();
     }
 
-    // minsu-23.09.12
+    // minsu-23.09.19
     @ApiOperation(value = "주문 수락 또는 거절", notes = "관리자가 주문을 수락 또는 거절합니다.")
     @PatchMapping("/receipt-status/{ordersId}")
     public ResponseEntity<Void> ordersReceiptModify(
         @PathVariable Long ordersId,
-        @RequestBody OrdersReceiptModifyForm ordersReceiptModifyForm) {
+        @RequestBody @Valid OrdersReceiptModifyForm ordersReceiptModifyForm) {
 
         ordersService.modifyOrdersReceiptStatus(ordersId,
             OrdersReceiptModifyDto.from(ordersReceiptModifyForm));
         return ResponseEntity.status(NO_CONTENT).build();
     }
 
-    // minsu-23.09.12
+    // minsu-23.09.19
     @ApiOperation(value = "주문 조리 예정 시간 선택", notes = "관리자가 수락된 주문 조리 예정 시간을 선택합니다.")
     @PatchMapping("/cooking-time/{ordersId}")
     public ResponseEntity<Void> ordersCookingTimeModify(
         @PathVariable Long ordersId,
-        @RequestBody OrdersCookingTimeModifyForm cookingTimeModifyForm) {
+        @RequestBody @Valid OrdersCookingTimeModifyForm cookingTimeModifyForm) {
 
         ordersService.modifyOrdersCookingTime(ordersId,
             OrdersCookingTimeModifyDto.from(cookingTimeModifyForm));

--- a/src/main/java/com/zerobase/cafebom/admin/controller/AdminOrdersController.java
+++ b/src/main/java/com/zerobase/cafebom/admin/controller/AdminOrdersController.java
@@ -2,13 +2,13 @@ package com.zerobase.cafebom.admin.controller;
 
 import static org.springframework.http.HttpStatus.NO_CONTENT;
 
+import com.zerobase.cafebom.admin.service.AdminOrdersService;
 import com.zerobase.cafebom.orders.dto.OrdersCookingTimeModifyDto;
 import com.zerobase.cafebom.orders.dto.OrdersCookingTimeModifyForm;
 import com.zerobase.cafebom.orders.dto.OrdersReceiptModifyDto;
 import com.zerobase.cafebom.orders.dto.OrdersReceiptModifyForm;
 import com.zerobase.cafebom.orders.dto.OrdersStatusModifyDto;
 import com.zerobase.cafebom.orders.dto.OrdersStatusModifyForm;
-import com.zerobase.cafebom.orders.service.OrdersService;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import javax.validation.Valid;
@@ -30,40 +30,40 @@ import org.springframework.web.bind.annotation.RestController;
 @PreAuthorize("hasRole('ROLE_ADMIN')")
 public class AdminOrdersController {
 
-    private final OrdersService ordersService;
+    private final AdminOrdersService adminOrdersService;
 
-    // minsu-23.09.19
+    // minsu-23.09.20
     @ApiOperation(value = "주문 상태 변경", notes = "관리자가 주문 상태를 변경합니다.")
     @PatchMapping("/status/{ordersId}")
     public ResponseEntity<Void> ordersStatusModify(
         @PathVariable Long ordersId,
         @RequestBody @Valid OrdersStatusModifyForm ordersStatusModifyForm) {
 
-        ordersService.modifyOrdersStatus(ordersId,
+        adminOrdersService.modifyOrdersStatus(ordersId,
             OrdersStatusModifyDto.from(ordersStatusModifyForm));
         return ResponseEntity.status(NO_CONTENT).build();
     }
 
-    // minsu-23.09.19
+    // minsu-23.09.20
     @ApiOperation(value = "주문 수락 또는 거절", notes = "관리자가 주문을 수락 또는 거절합니다.")
     @PatchMapping("/receipt-status/{ordersId}")
     public ResponseEntity<Void> ordersReceiptModify(
         @PathVariable Long ordersId,
         @RequestBody @Valid OrdersReceiptModifyForm ordersReceiptModifyForm) {
 
-        ordersService.modifyOrdersReceiptStatus(ordersId,
+        adminOrdersService.modifyOrdersReceiptStatus(ordersId,
             OrdersReceiptModifyDto.from(ordersReceiptModifyForm));
         return ResponseEntity.status(NO_CONTENT).build();
     }
 
-    // minsu-23.09.19
+    // minsu-23.09.20
     @ApiOperation(value = "주문 조리 예정 시간 선택", notes = "관리자가 수락된 주문 조리 예정 시간을 선택합니다.")
     @PatchMapping("/cooking-time/{ordersId}")
     public ResponseEntity<Void> ordersCookingTimeModify(
         @PathVariable Long ordersId,
         @RequestBody @Valid OrdersCookingTimeModifyForm cookingTimeModifyForm) {
 
-        ordersService.modifyOrdersCookingTime(ordersId,
+        adminOrdersService.modifyOrdersCookingTime(ordersId,
             OrdersCookingTimeModifyDto.from(cookingTimeModifyForm));
         return ResponseEntity.status(NO_CONTENT).build();
     }

--- a/src/main/java/com/zerobase/cafebom/admin/service/AdminOrdersService.java
+++ b/src/main/java/com/zerobase/cafebom/admin/service/AdminOrdersService.java
@@ -1,0 +1,102 @@
+package com.zerobase.cafebom.admin.service;
+
+import static com.zerobase.cafebom.exception.ErrorCode.ORDERS_ALREADY_CANCELED;
+import static com.zerobase.cafebom.exception.ErrorCode.ORDERS_COOKING_TIME_ALREADY_SET;
+import static com.zerobase.cafebom.exception.ErrorCode.ORDERS_NOT_EXISTS;
+import static com.zerobase.cafebom.exception.ErrorCode.ORDERS_NOT_RECEIVED_STATUS;
+import static com.zerobase.cafebom.exception.ErrorCode.ORDERS_STATUS_ONLY_NEXT;
+
+import com.zerobase.cafebom.exception.CustomException;
+import com.zerobase.cafebom.orders.domain.Orders;
+import com.zerobase.cafebom.orders.domain.OrdersRepository;
+import com.zerobase.cafebom.orders.dto.OrdersCookingTimeModifyDto;
+import com.zerobase.cafebom.orders.dto.OrdersReceiptModifyDto;
+import com.zerobase.cafebom.orders.dto.OrdersStatusModifyDto;
+import com.zerobase.cafebom.type.OrdersCookingStatus;
+import com.zerobase.cafebom.type.OrdersCookingTime;
+import com.zerobase.cafebom.type.OrdersReceiptStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AdminOrdersService {
+
+    private final OrdersRepository ordersRepository;
+
+    // 다음 상태 이외엔 주문 상태 변경 불가-minsu-23.09.12
+    private OrdersCookingStatus modifyNextCookingStatus(OrdersCookingStatus currentStatus) {
+        switch (currentStatus) {
+            case NONE:
+                return OrdersCookingStatus.COOKING;
+            case COOKING:
+                return OrdersCookingStatus.PREPARED;
+            case PREPARED:
+                return OrdersCookingStatus.FINISHED;
+            default:
+                return null;
+        }
+    }
+
+    // 주문 상태 변경-minsu-23.09.19
+    public void modifyOrdersStatus(Long ordersId, OrdersStatusModifyDto ordersStatusModifyDto) {
+        Orders orders = ordersRepository.findById(ordersId)
+            .orElseThrow(() -> new CustomException(ORDERS_NOT_EXISTS));
+
+        OrdersCookingStatus newStatus = ordersStatusModifyDto.getNewStatus();
+        OrdersCookingStatus currentStatus = orders.getCookingStatus();
+        OrdersCookingStatus nextStatus = modifyNextCookingStatus(currentStatus);
+
+        if (newStatus != nextStatus) {
+            throw new CustomException(ORDERS_STATUS_ONLY_NEXT);
+        }
+
+        orders.modifyReceivedTime(newStatus);
+
+        ordersRepository.save(orders);
+    }
+
+    // 주문 수락 또는 거절-minsu-23.09.19
+    public void modifyOrdersReceiptStatus(Long ordersId,
+        OrdersReceiptModifyDto ordersReceiptModifyDto) {
+        Orders orders = ordersRepository.findById(ordersId)
+            .orElseThrow(() -> new CustomException(ORDERS_NOT_EXISTS));
+
+        OrdersReceiptStatus newReceiptStatus = ordersReceiptModifyDto.getNewReceiptStatus();
+
+        if (newReceiptStatus == OrdersReceiptStatus.RECEIVED) {
+            orders.modifyReceivedTime(OrdersCookingStatus.COOKING);
+        }
+
+        if (orders.getReceiptStatus() == OrdersReceiptStatus.CANCELED
+            || orders.getReceiptStatus() == OrdersReceiptStatus.REJECTED) {
+            throw new CustomException(ORDERS_ALREADY_CANCELED);
+        }
+
+        orders.modifyReceiptStatus(newReceiptStatus);
+
+        ordersRepository.save(orders);
+    }
+
+    // 조리 예정 시간 선택-minsu-23.09.19
+    public void modifyOrdersCookingTime(Long ordersId,
+        OrdersCookingTimeModifyDto cookingTimeModifyDto) {
+        Orders orders = ordersRepository.findById(ordersId)
+            .orElseThrow(() -> new CustomException(ORDERS_NOT_EXISTS));
+
+        OrdersCookingTime selectedCookingTime = cookingTimeModifyDto.getSelectedCookingTime();
+
+        if (orders.getReceiptStatus() != OrdersReceiptStatus.RECEIVED) {
+            throw new CustomException(ORDERS_NOT_RECEIVED_STATUS);
+        }
+
+        if (orders.getCookingTime() != OrdersCookingTime.NONE
+            && selectedCookingTime != orders.getCookingTime()) {
+            throw new CustomException(ORDERS_COOKING_TIME_ALREADY_SET);
+        }
+
+        orders.modifyCookingTime(selectedCookingTime);
+
+        ordersRepository.save(orders);
+    }
+}

--- a/src/main/java/com/zerobase/cafebom/exception/ErrorCode.java
+++ b/src/main/java/com/zerobase/cafebom/exception/ErrorCode.java
@@ -1,10 +1,12 @@
 package com.zerobase.cafebom.exception;
 
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.CONFLICT;
+import static org.springframework.http.HttpStatus.FORBIDDEN;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
-
-import static org.springframework.http.HttpStatus.*;
 
 @Getter
 @AllArgsConstructor
@@ -28,6 +30,7 @@ public enum ErrorCode {
     ORDERS_ALREADY_CANCELED("이미 취소된 주문입니다.", BAD_REQUEST),
     ORDERS_NOT_RECEIVED_STATUS("수락되지 않은 주문입니다.", BAD_REQUEST),
     ORDERS_COOKING_TIME_ALREADY_SET("이미 조리 예정 시간이 설정되어 있습니다.", BAD_REQUEST),
+    ORDERS_NOT_ACCESS("해당 주문에 대한 접근 권한이 없습니다.", FORBIDDEN),
     START_DATE_AND_END_DATE_ARE_ESSENTIAL("시작 날짜와 끝 날짜를 입력해야 합니다.", BAD_REQUEST),
 
     // Product

--- a/src/main/java/com/zerobase/cafebom/orders/controller/OrdersController.java
+++ b/src/main/java/com/zerobase/cafebom/orders/controller/OrdersController.java
@@ -20,7 +20,7 @@ import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -33,9 +33,9 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "orders-controller", description = "사용자 주문 관련 API")
 @RestController
-@Controller
 @RequiredArgsConstructor
 @RequestMapping("/auth/orders")
+@PreAuthorize("hasRole('ROLE_USER')")
 public class OrdersController {
 
     private final OrdersHistoryService orderService;
@@ -44,22 +44,24 @@ public class OrdersController {
 
     private final TokenProvider tokenProvider;
 
-    // minsu-23.09.12
+    // minsu-23.09.19
     @ApiOperation(value = "조리 경과 시간 조회", notes = "사용자가 조리 경과 시간을 조회합니다.")
     @GetMapping("/elapsed-time/{ordersId}")
-    public ResponseEntity<OrdersElapsedFindForm> elapsedTimeGet(@PathVariable Long ordersId) {
-        Long elapsedTimeMinutes = ordersService.findElapsedTime(ordersId);
+    public ResponseEntity<OrdersElapsedFindForm> elapsedTimeGet(
+        @RequestHeader(name = "Authorization") String token, @PathVariable Long ordersId) {
+        Long elapsedTimeMinutes = ordersService.findElapsedTime(token, ordersId);
         OrdersElapsedFindForm response = OrdersElapsedFindForm.builder()
             .elapsedTimeMinutes(elapsedTimeMinutes)
             .build();
         return ResponseEntity.ok(response);
     }
 
-    // minsu-23.09.12
+    // minsu-23.09.19
     @ApiOperation(value = "주문 취소", notes = "관리자가 주문을 수락하기 전에 사용자가 주문을 취소합니다.")
     @PatchMapping("/cancel/{ordersId}")
-    public ResponseEntity<Void> ordersCancelModify(@PathVariable Long ordersId) {
-        ordersService.modifyOrdersCancel(ordersId);
+    public ResponseEntity<Void> ordersCancelModify(
+        @RequestHeader(name = "Authorization") String token, @PathVariable Long ordersId) {
+        ordersService.modifyOrdersCancel(token, ordersId);
         return ResponseEntity.status(NO_CONTENT).build();
     }
 

--- a/src/main/java/com/zerobase/cafebom/orders/service/OrdersService.java
+++ b/src/main/java/com/zerobase/cafebom/orders/service/OrdersService.java
@@ -5,12 +5,9 @@ import static com.zerobase.cafebom.exception.ErrorCode.MEMBER_NOT_EXISTS;
 import static com.zerobase.cafebom.exception.ErrorCode.OPTION_NOT_EXISTS;
 import static com.zerobase.cafebom.exception.ErrorCode.ORDERS_ALREADY_CANCELED;
 import static com.zerobase.cafebom.exception.ErrorCode.ORDERS_ALREADY_COOKING_STATUS;
-import static com.zerobase.cafebom.exception.ErrorCode.ORDERS_COOKING_TIME_ALREADY_SET;
 import static com.zerobase.cafebom.exception.ErrorCode.ORDERS_NOT_ACCESS;
 import static com.zerobase.cafebom.exception.ErrorCode.ORDERS_NOT_COOKING_STATUS;
 import static com.zerobase.cafebom.exception.ErrorCode.ORDERS_NOT_EXISTS;
-import static com.zerobase.cafebom.exception.ErrorCode.ORDERS_NOT_RECEIVED_STATUS;
-import static com.zerobase.cafebom.exception.ErrorCode.ORDERS_STATUS_ONLY_NEXT;
 
 import com.zerobase.cafebom.cart.domain.Cart;
 import com.zerobase.cafebom.cart.domain.CartRepository;
@@ -23,16 +20,12 @@ import com.zerobase.cafebom.option.domain.OptionRepository;
 import com.zerobase.cafebom.orders.domain.Orders;
 import com.zerobase.cafebom.orders.domain.OrdersRepository;
 import com.zerobase.cafebom.orders.dto.OrdersAddDto;
-import com.zerobase.cafebom.orders.dto.OrdersCookingTimeModifyDto;
-import com.zerobase.cafebom.orders.dto.OrdersReceiptModifyDto;
-import com.zerobase.cafebom.orders.dto.OrdersStatusModifyDto;
 import com.zerobase.cafebom.ordersproduct.domain.OrdersProduct;
 import com.zerobase.cafebom.ordersproduct.domain.OrdersProductRepository;
 import com.zerobase.cafebom.ordersproductoption.domain.OrdersProductOption;
 import com.zerobase.cafebom.ordersproductoption.domain.OrdersProductOptionRepository;
 import com.zerobase.cafebom.security.TokenProvider;
 import com.zerobase.cafebom.type.OrdersCookingStatus;
-import com.zerobase.cafebom.type.OrdersCookingTime;
 import com.zerobase.cafebom.type.OrdersReceiptStatus;
 import java.time.Duration;
 import java.time.LocalDateTime;
@@ -58,38 +51,6 @@ public class OrdersService {
     private final OrdersProductOptionRepository ordersProductOptionRepository;
 
     private final TokenProvider tokenProvider;
-
-    // 다음 상태 이외엔 주문 상태 변경 불가-minsu-23.09.12
-    private OrdersCookingStatus modifyNextCookingStatus(OrdersCookingStatus currentStatus) {
-        switch (currentStatus) {
-            case NONE:
-                return OrdersCookingStatus.COOKING;
-            case COOKING:
-                return OrdersCookingStatus.PREPARED;
-            case PREPARED:
-                return OrdersCookingStatus.FINISHED;
-            default:
-                return null;
-        }
-    }
-
-    // 주문 상태 변경-minsu-23.09.19
-    public void modifyOrdersStatus(Long ordersId, OrdersStatusModifyDto ordersStatusModifyDto) {
-        Orders orders = ordersRepository.findById(ordersId)
-            .orElseThrow(() -> new CustomException(ORDERS_NOT_EXISTS));
-
-        OrdersCookingStatus newStatus = ordersStatusModifyDto.getNewStatus();
-        OrdersCookingStatus currentStatus = orders.getCookingStatus();
-        OrdersCookingStatus nextStatus = modifyNextCookingStatus(currentStatus);
-
-        if (newStatus != nextStatus) {
-            throw new CustomException(ORDERS_STATUS_ONLY_NEXT);
-        }
-
-        orders.modifyReceivedTime(newStatus);
-
-        ordersRepository.save(orders);
-    }
 
     // 주문 수락 시간 저장-minsu-23.09.12
     public LocalDateTime saveReceivedTime(Long ordersId) {
@@ -125,28 +86,6 @@ public class OrdersService {
         return duration.toMinutes();
     }
 
-    // 주문 수락 또는 거절-minsu-23.09.19
-    public void modifyOrdersReceiptStatus(Long ordersId,
-        OrdersReceiptModifyDto ordersReceiptModifyDto) {
-        Orders orders = ordersRepository.findById(ordersId)
-            .orElseThrow(() -> new CustomException(ORDERS_NOT_EXISTS));
-
-        OrdersReceiptStatus newReceiptStatus = ordersReceiptModifyDto.getNewReceiptStatus();
-
-        if (newReceiptStatus == OrdersReceiptStatus.RECEIVED) {
-            orders.modifyReceivedTime(OrdersCookingStatus.COOKING);
-        }
-
-        if (orders.getReceiptStatus() == OrdersReceiptStatus.CANCELED
-            || orders.getReceiptStatus() == OrdersReceiptStatus.REJECTED) {
-            throw new CustomException(ORDERS_ALREADY_CANCELED);
-        }
-
-        orders.modifyReceiptStatus(newReceiptStatus);
-
-        ordersRepository.save(orders);
-    }
-
     // 주문 취소-minsu-23.09.19
     public void modifyOrdersCancel(String token, Long ordersId) {
         Long userId = tokenProvider.getId(token);
@@ -169,28 +108,6 @@ public class OrdersService {
         }
 
         orders.modifyReceiptStatus(OrdersReceiptStatus.CANCELED);
-
-        ordersRepository.save(orders);
-    }
-
-    // 조리 예정 시간 선택-minsu-23.09.19
-    public void modifyOrdersCookingTime(Long ordersId,
-        OrdersCookingTimeModifyDto cookingTimeModifyDto) {
-        Orders orders = ordersRepository.findById(ordersId)
-            .orElseThrow(() -> new CustomException(ORDERS_NOT_EXISTS));
-
-        OrdersCookingTime selectedCookingTime = cookingTimeModifyDto.getSelectedCookingTime();
-
-        if (orders.getReceiptStatus() != OrdersReceiptStatus.RECEIVED) {
-            throw new CustomException(ORDERS_NOT_RECEIVED_STATUS);
-        }
-
-        if (orders.getCookingTime() != OrdersCookingTime.NONE
-            && selectedCookingTime != orders.getCookingTime()) {
-            throw new CustomException(ORDERS_COOKING_TIME_ALREADY_SET);
-        }
-
-        orders.modifyCookingTime(selectedCookingTime);
 
         ordersRepository.save(orders);
     }

--- a/src/test/java/com/zerobase/cafebom/admin/controller/AdminOrdersControllerTest.java
+++ b/src/test/java/com/zerobase/cafebom/admin/controller/AdminOrdersControllerTest.java
@@ -8,13 +8,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.zerobase.cafebom.admin.service.AdminOrdersService;
 import com.zerobase.cafebom.exception.CustomException;
 import com.zerobase.cafebom.exception.ErrorCode;
 import com.zerobase.cafebom.orders.dto.OrdersCookingTimeModifyForm;
 import com.zerobase.cafebom.orders.dto.OrdersReceiptModifyForm;
 import com.zerobase.cafebom.orders.dto.OrdersStatusModifyDto;
 import com.zerobase.cafebom.orders.dto.OrdersStatusModifyForm;
-import com.zerobase.cafebom.orders.service.OrdersService;
 import com.zerobase.cafebom.security.TokenProvider;
 import com.zerobase.cafebom.type.OrdersCookingTime;
 import com.zerobase.cafebom.type.OrdersReceiptStatus;
@@ -38,7 +38,7 @@ public class AdminOrdersControllerTest {
     private ObjectMapper objectMapper;
 
     @MockBean
-    private OrdersService ordersService;
+    private AdminOrdersService adminOrdersService;
 
     @MockBean
     private TokenProvider tokenProvider;
@@ -67,7 +67,7 @@ public class AdminOrdersControllerTest {
         // given
         Long ordersId = 1L;
         doThrow(new CustomException(ErrorCode.ORDERS_NOT_EXISTS))
-            .when(ordersService).modifyOrdersStatus(ordersId,
+            .when(adminOrdersService).modifyOrdersStatus(ordersId,
                 OrdersStatusModifyDto.builder().newStatus(COOKING).build()
             );
 

--- a/src/test/java/com/zerobase/cafebom/admin/service/AdminOrdersServiceTest.java
+++ b/src/test/java/com/zerobase/cafebom/admin/service/AdminOrdersServiceTest.java
@@ -1,0 +1,131 @@
+package com.zerobase.cafebom.admin.service;
+
+import static com.zerobase.cafebom.exception.ErrorCode.ORDERS_ALREADY_CANCELED;
+import static com.zerobase.cafebom.exception.ErrorCode.ORDERS_COOKING_TIME_ALREADY_SET;
+import static com.zerobase.cafebom.exception.ErrorCode.ORDERS_NOT_RECEIVED_STATUS;
+import static com.zerobase.cafebom.exception.ErrorCode.ORDERS_STATUS_ONLY_NEXT;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+
+import com.zerobase.cafebom.exception.CustomException;
+import com.zerobase.cafebom.orders.domain.Orders;
+import com.zerobase.cafebom.orders.domain.OrdersRepository;
+import com.zerobase.cafebom.orders.dto.OrdersCookingTimeModifyDto;
+import com.zerobase.cafebom.orders.dto.OrdersReceiptModifyDto;
+import com.zerobase.cafebom.orders.dto.OrdersStatusModifyDto;
+import com.zerobase.cafebom.type.OrdersCookingStatus;
+import com.zerobase.cafebom.type.OrdersCookingTime;
+import com.zerobase.cafebom.type.OrdersReceiptStatus;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.MockMvc;
+
+@ExtendWith(MockitoExtension.class)
+class AdminOrdersServiceTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @InjectMocks
+    private AdminOrdersService adminOrdersService;
+
+    @Mock
+    private OrdersRepository ordersRepository;
+
+    // minsu-23.09.20
+    @Test
+    @DisplayName("주문 상태 변경 실패 - 주문 상태는 전으로 돌아갈 수 없음")
+    void failUpdateOrdersStatusOnlyNext() {
+        // given
+        Long ordersId = 1L;
+        given(ordersRepository.findById(ordersId))
+            .willReturn(
+                Optional.of(Orders.builder().cookingStatus(OrdersCookingStatus.COOKING).build()));
+
+        OrdersStatusModifyDto modifyDto = OrdersStatusModifyDto.builder()
+            .newStatus(OrdersCookingStatus.NONE)
+            .build();
+
+        // then
+        CustomException exception = assertThrows(CustomException.class,
+            () -> adminOrdersService.modifyOrdersStatus(ordersId, modifyDto));
+        assertThat(exception.getErrorCode()).isEqualTo(ORDERS_STATUS_ONLY_NEXT);
+    }
+
+    // minsu-23.09.20
+    @Test
+    @DisplayName("주문 수락/거절 실패 - 주문이 이미 취소된 경우")
+    void failOrdersReceiptAlreadyCanceled() {
+        // given
+        Long ordersId = 1L;
+
+        given(ordersRepository.findById(ordersId))
+            .willReturn(
+                Optional.of(Orders.builder().receiptStatus(OrdersReceiptStatus.CANCELED).build()));
+
+        OrdersReceiptModifyDto modifyDto = OrdersReceiptModifyDto.builder()
+            .newReceiptStatus(OrdersReceiptStatus.RECEIVED)
+            .build();
+
+        // when
+        CustomException exception = assertThrows(CustomException.class,
+            () -> adminOrdersService.modifyOrdersReceiptStatus(ordersId, modifyDto));
+
+        // then
+        assertThat(exception.getErrorCode()).isEqualTo(ORDERS_ALREADY_CANCELED);
+    }
+
+    // minsu-23.09.20
+    @Test
+    @DisplayName("관리자 조리 예정 시간 선택 실패 - 주문이 수락되지 않은 경우")
+    void failAdminOrdersCookingTimeModifyNotReceived() {
+        // given
+        Long ordersId = 1L;
+        given(ordersRepository.findById(ordersId))
+            .willReturn(
+                Optional.of(Orders.builder().receiptStatus(OrdersReceiptStatus.CANCELED).build()));
+
+        OrdersCookingTimeModifyDto modifyDto = OrdersCookingTimeModifyDto.builder()
+            .selectedCookingTime(OrdersCookingTime._5_TO_10_MINUTES)
+            .build();
+
+        // then
+        CustomException exception = assertThrows(CustomException.class,
+            () -> adminOrdersService.modifyOrdersCookingTime(ordersId, modifyDto));
+        assertThat(exception.getErrorCode()).isEqualTo(ORDERS_NOT_RECEIVED_STATUS);
+    }
+
+    // minsu-23.09.20
+    @Test
+    @DisplayName("관리자 조리 예정 시간 선택 실패 - 이미 조리 예정 시간이 설정되어 있는 경우")
+    void failAdminOrdersCookingTimeModifyAlreadySet() {
+        // given
+        Long ordersId = 1L;
+        Orders orders = Orders.builder()
+            .id(ordersId)
+            .cookingStatus(OrdersCookingStatus.COOKING)
+            .receiptStatus(OrdersReceiptStatus.RECEIVED)
+            .cookingTime(OrdersCookingTime._5_TO_10_MINUTES) // Already set
+            .receivedTime(LocalDateTime.now())
+            .build();
+
+        given(ordersRepository.findById(ordersId)).willReturn(Optional.of(orders));
+
+        OrdersCookingTimeModifyDto modifyDto = OrdersCookingTimeModifyDto.builder()
+            .selectedCookingTime(OrdersCookingTime.OVER_25_MINUTES)
+            .build();
+
+        // then
+        CustomException exception = assertThrows(CustomException.class,
+            () -> adminOrdersService.modifyOrdersCookingTime(ordersId, modifyDto));
+        assertThat(exception.getErrorCode()).isEqualTo(ORDERS_COOKING_TIME_ALREADY_SET);
+    }
+}

--- a/src/test/java/com/zerobase/cafebom/orders/controller/OrdersStatusControllerTest.java
+++ b/src/test/java/com/zerobase/cafebom/orders/controller/OrdersStatusControllerTest.java
@@ -44,7 +44,9 @@ public class OrdersStatusControllerTest {
     @MockBean
     private MemberRepository memberRepository;
 
-    // minsu-23.09.12
+    private String token = "Bearer token";
+
+    // minsu-23.09.19
     @Test
     @DisplayName("주문 경과 시간 조회 성공 - 주문에 대한 경과 시간 조회")
     void successGetElapsedTime() throws Exception {
@@ -52,16 +54,17 @@ public class OrdersStatusControllerTest {
         Long ordersId = 1L;
         Long elapsedTimeMinutes = 30L;
 
-        given(ordersService.findElapsedTime(ordersId)).willReturn(elapsedTimeMinutes);
+        given(ordersService.findElapsedTime(token, ordersId)).willReturn(elapsedTimeMinutes);
 
         // then
-        mockMvc.perform(get("/auth/orders/elapsed-time/{ordersId}", ordersId))
+        mockMvc.perform(get("/auth/orders/elapsed-time/{ordersId}", ordersId)
+                .header("Authorization", token))
             .andExpect(status().isOk())
             .andExpect(content().json("{\"elapsedTimeMinutes\": " + elapsedTimeMinutes + "}"))
             .andDo(print());
     }
 
-    // minsu-23.09.12
+    // minsu-23.09.19
     @Test
     @DisplayName("사용자 주문 취소 성공 - 주문을 정상적으로 취소")
     void successUserOrdersCancel() throws Exception {
@@ -70,6 +73,7 @@ public class OrdersStatusControllerTest {
 
         // then
         mockMvc.perform(patch("/auth/orders/cancel/{ordersId}", ordersId)
+                .header("Authorization", token)
                 .contentType(MediaType.APPLICATION_JSON)
                 .with(csrf()))
             .andExpect(status().isNoContent())

--- a/src/test/java/com/zerobase/cafebom/orders/service/OrdersStatusServiceTest.java
+++ b/src/test/java/com/zerobase/cafebom/orders/service/OrdersStatusServiceTest.java
@@ -1,30 +1,19 @@
 package com.zerobase.cafebom.orders.service;
 
-import static com.zerobase.cafebom.exception.ErrorCode.ORDERS_ALREADY_CANCELED;
 import static com.zerobase.cafebom.exception.ErrorCode.ORDERS_ALREADY_COOKING_STATUS;
-import static com.zerobase.cafebom.exception.ErrorCode.ORDERS_COOKING_TIME_ALREADY_SET;
 import static com.zerobase.cafebom.exception.ErrorCode.ORDERS_NOT_COOKING_STATUS;
 import static com.zerobase.cafebom.exception.ErrorCode.ORDERS_NOT_EXISTS;
-import static com.zerobase.cafebom.exception.ErrorCode.ORDERS_NOT_RECEIVED_STATUS;
-import static com.zerobase.cafebom.exception.ErrorCode.ORDERS_STATUS_ONLY_NEXT;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.given;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.zerobase.cafebom.exception.CustomException;
 import com.zerobase.cafebom.member.domain.Member;
-import com.zerobase.cafebom.member.domain.MemberRepository;
 import com.zerobase.cafebom.orders.domain.Orders;
 import com.zerobase.cafebom.orders.domain.OrdersRepository;
-import com.zerobase.cafebom.orders.dto.OrdersCookingTimeModifyDto;
-import com.zerobase.cafebom.orders.dto.OrdersReceiptModifyDto;
-import com.zerobase.cafebom.orders.dto.OrdersStatusModifyDto;
 import com.zerobase.cafebom.security.TokenProvider;
 import com.zerobase.cafebom.type.OrdersCookingStatus;
-import com.zerobase.cafebom.type.OrdersCookingTime;
 import com.zerobase.cafebom.type.OrdersReceiptStatus;
-import java.time.LocalDateTime;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -41,17 +30,11 @@ class OrdersStatusServiceTest {
     @Autowired
     private MockMvc mockMvc;
 
-    @Autowired
-    private ObjectMapper objectMapper;
-
     @InjectMocks
     private OrdersService ordersService;
 
     @Mock
     private OrdersRepository ordersRepository;
-
-    @Mock
-    private MemberRepository memberRepository;
 
     @Mock
     private TokenProvider tokenProvider;
@@ -61,26 +44,6 @@ class OrdersStatusServiceTest {
     Member member = Member.builder()
         .id(1L)
         .build();
-
-    // minsu-23.09.15
-    @Test
-    @DisplayName("주문 상태 변경 실패 - 주문 상태는 전으로 돌아갈 수 없음")
-    void failUpdateOrdersStatusOnlyNext() {
-        // given
-        Long ordersId = 1L;
-        given(ordersRepository.findById(ordersId))
-            .willReturn(
-                Optional.of(Orders.builder().cookingStatus(OrdersCookingStatus.COOKING).build()));
-
-        OrdersStatusModifyDto modifyDto = OrdersStatusModifyDto.builder()
-            .newStatus(OrdersCookingStatus.NONE)
-            .build();
-
-        // then
-        CustomException exception = assertThrows(CustomException.class,
-            () -> ordersService.modifyOrdersStatus(ordersId, modifyDto));
-        assertThat(exception.getErrorCode()).isEqualTo(ORDERS_STATUS_ONLY_NEXT);
-    }
 
     // minsu-23.09.19
     @Test
@@ -117,29 +80,6 @@ class OrdersStatusServiceTest {
         assertThat(exception.getErrorCode()).isEqualTo(ORDERS_NOT_COOKING_STATUS);
     }
 
-    // minsu-23.09.01
-    @Test
-    @DisplayName("주문 수락/거절 실패 - 주문이 이미 취소된 경우")
-    void failOrdersReceiptAlreadyCanceled() {
-        // given
-        Long ordersId = 1L;
-
-        given(ordersRepository.findById(ordersId))
-            .willReturn(
-                Optional.of(Orders.builder().receiptStatus(OrdersReceiptStatus.CANCELED).build()));
-
-        OrdersReceiptModifyDto modifyDto = OrdersReceiptModifyDto.builder()
-            .newReceiptStatus(OrdersReceiptStatus.RECEIVED)
-            .build();
-
-        // when
-        CustomException exception = assertThrows(CustomException.class,
-            () -> ordersService.modifyOrdersReceiptStatus(ordersId, modifyDto));
-
-        // then
-        assertThat(exception.getErrorCode()).isEqualTo(ORDERS_ALREADY_CANCELED);
-    }
-
     // minsu-23.09.19
     @Test
     @DisplayName("사용자 주문 취소 실패 - 이미 주문이 조리 중인 경우")
@@ -159,51 +99,5 @@ class OrdersStatusServiceTest {
         CustomException exception = assertThrows(CustomException.class,
             () -> ordersService.modifyOrdersCancel(token, ordersId));
         assertThat(exception.getErrorCode()).isEqualTo(ORDERS_ALREADY_COOKING_STATUS);
-    }
-
-    // minsu-23.09.01
-    @Test
-    @DisplayName("관리자 조리 예정 시간 선택 실패 - 주문이 수락되지 않은 경우")
-    void failAdminOrdersCookingTimeModifyNotReceived() {
-        // given
-        Long ordersId = 1L;
-        given(ordersRepository.findById(ordersId))
-            .willReturn(
-                Optional.of(Orders.builder().receiptStatus(OrdersReceiptStatus.CANCELED).build()));
-
-        OrdersCookingTimeModifyDto modifyDto = OrdersCookingTimeModifyDto.builder()
-            .selectedCookingTime(OrdersCookingTime._5_TO_10_MINUTES)
-            .build();
-
-        // then
-        CustomException exception = assertThrows(CustomException.class,
-            () -> ordersService.modifyOrdersCookingTime(ordersId, modifyDto));
-        assertThat(exception.getErrorCode()).isEqualTo(ORDERS_NOT_RECEIVED_STATUS);
-    }
-
-    // minsu-23.09.01
-    @Test
-    @DisplayName("관리자 조리 예정 시간 선택 실패 - 이미 조리 예정 시간이 설정되어 있는 경우")
-    void failAdminOrdersCookingTimeModifyAlreadySet() {
-        // given
-        Long ordersId = 1L;
-        Orders orders = Orders.builder()
-            .id(ordersId)
-            .cookingStatus(OrdersCookingStatus.COOKING)
-            .receiptStatus(OrdersReceiptStatus.RECEIVED)
-            .cookingTime(OrdersCookingTime._5_TO_10_MINUTES) // Already set
-            .receivedTime(LocalDateTime.now())
-            .build();
-
-        given(ordersRepository.findById(ordersId)).willReturn(Optional.of(orders));
-
-        OrdersCookingTimeModifyDto modifyDto = OrdersCookingTimeModifyDto.builder()
-            .selectedCookingTime(OrdersCookingTime.OVER_25_MINUTES)
-            .build();
-
-        // then
-        CustomException exception = assertThrows(CustomException.class,
-            () -> ordersService.modifyOrdersCookingTime(ordersId, modifyDto));
-        assertThat(exception.getErrorCode()).isEqualTo(ORDERS_COOKING_TIME_ALREADY_SET);
     }
 }


### PR DESCRIPTION
### ☀️ 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**🌱 AS-IS**
- 주문 관련 기능에 관리자/사용자 권한이 제대로 부여가 안되어 있었음

**🌷 TO-BE**
- 주문 관련 기능에 @PreAuthorize을 사용하여 관리자/사용자로 구분하여 권한 부여
- 사용자 주문 기능 RequestHeader에 사용자에 따라 고유 토큰을 받아오도록 수정
- 불필요한 @Transactional 삭제
- 관리자 주문 관련 서비스가 admin 파일과 분리 되어 있었어서 파일 위치 수정 (order -> admin) 

### 🗣️ Comment
<!-- 팀원들에게 질문이 있다던가, 이 PR에 대해 추가적인 설명 -->


### ⚡️ 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] 전체 테스트 성공
- [x] API 테스트 