### PR TITLE
Fix: order 엔티티 cookingTime 컬럼의 notnull 어노테이션 삭제

### DIFF
--- a/src/main/java/com/zerobase/cafebom/front/order/domain/Order.java
+++ b/src/main/java/com/zerobase/cafebom/front/order/domain/Order.java
@@ -48,7 +48,6 @@ public class Order extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private OrderCookingStatus cookingStatus;
 
-    @NotNull
     @Enumerated(EnumType.STRING)
     private OrderCookingTime cookingTime;
 


### PR DESCRIPTION
### ☀️ 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**🌱 AS-IS**
- order 엔티티의 cookingTime이 null이 될 수도 있는데 notnull 어노테이션이 붙어있어서 오류가 남.
(주문이 취소된 경우에는 준비예정시간이 Null임) 

**🌷 TO-BE**
- notnull 어노테이션 삭제. db에도 null이 될 수 있도록 변경함

### 🗣️ Comment
<!-- 팀원들에게 질문이 있다던가, 이 PR에 대해 추가적인 설명 -->


### ⚡️ 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 전체 테스트 성공